### PR TITLE
Add dkonchekov's file list cli params

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "vtc": "dist/cli.js"
   },
   "scripts": {
+    "prepare": "npm run compile",
     "compile": "tsc -p .",
     "watch": "tsc --watch",
     "typings": "tsc -d --emitDeclarationOnly --declarationDir typings",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,18 +9,15 @@ const {
   onlyTemplate,
   onlyTypeScript,
   excludeDir,
+  _,
 } = minimist(process.argv.slice(2));
-
-if (!workspace) {
-  throw new Error("--workspace is required");
-}
-
 const cwd = process.cwd();
 
 check({
-  workspace: path.resolve(cwd, workspace),
+  workspace: path.resolve(cwd, workspace || "."),
   srcDir: srcDir && path.resolve(cwd, srcDir),
   onlyTemplate,
   onlyTypeScript,
   excludeDir,
+  files: _,
 });


### PR DESCRIPTION
This PR adds dkonchekov's changes to support specifying the files to be checked, instead of the whole folder.
This is especially useful for pre-commit hooks, where you don't want all of the files checked, just those that have changed.

For those looking to set up their own pre-commit hooks, here's what I added to my package.json:
```
"husky": {
  "hooks": {
    "pre-commit": "lint-staged"
  }
},
"lint-staged": {
  "src/**/*.{js,ts,vue}": "eslint --cache --fix",
  "src/**/*.vue": "vue-type-check --onlyTemplate --workspace ../../.."
}
```