### PR TITLE
Remove unneeded package; move types packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "typescript": "^3.9.6"
   },
   "devDependencies": {
-    "@types/chalk": "^2.2.0",
     "@types/eslint": "^7.2.0",
     "@types/glob": "^7.1.3",
     "@types/minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,6 @@
   ],
   "typings": "typings/index.d.ts",
   "dependencies": {
-    "@types/chalk": "^2.2.0",
-    "@types/eslint": "^7.2.0",
-    "@types/glob": "^7.1.3",
-    "@types/minimist": "^1.2.0",
-    "@types/prettier": "^2.0.2",
-    "@types/progress": "^2.0.3",
     "chalk": "^4.1.0",
     "glob": "^7.1.6",
     "minimist": "^1.2.5",
@@ -49,6 +43,12 @@
     "typescript": "^3.9.6"
   },
   "devDependencies": {
+    "@types/chalk": "^2.2.0",
+    "@types/eslint": "^7.2.0",
+    "@types/glob": "^7.1.3",
+    "@types/minimist": "^1.2.0",
+    "@types/prettier": "^2.0.2",
+    "@types/progress": "^2.0.3",
     "typescript": "^3.9.6",
     "vue": "^2.6.10"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,13 +172,6 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@types/chalk@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
-  integrity sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==
-  dependencies:
-    chalk "*"
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -643,14 +636,6 @@ ccount@^1.0.0, ccount@^1.0.4:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.5.tgz#ac82a944905a65ce204eb03023157edf29425c17"
   integrity sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==
 
-chalk@*, chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chalk@1.1.3, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -670,6 +655,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.0, chalk@^2.4
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 character-entities-html4@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
This branch:

- Removes unneeded `@types/chalk` package (Chalk comes with its own type definitions)

- Moves type definitions to `devDependencies` (They are needed only in this project's development environment, not in production.)

Resolves Issue #7.